### PR TITLE
There's no need to depend on Hangfire and bring SqlServer support in

### DIFF
--- a/src/Hangfire.Prometheus/Hangfire.Prometheus/Hangfire.Prometheus.csproj
+++ b/src/Hangfire.Prometheus/Hangfire.Prometheus/Hangfire.Prometheus.csproj
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.7.1" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.1" />
     <PackageReference Include="prometheus-net" Version="3.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
The current code depends on Hangfire which brings Hangfire.SqlServer into the mix. This is not needed, this PR reduces the dependencies.